### PR TITLE
Dropped failsafe plugin from library archetype

### DIFF
--- a/java-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/java-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -357,18 +357,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>


### PR DESCRIPTION
It's not being used.