### PR TITLE
Removed prefix from dependencies & plugins

### DIFF
--- a/java-application-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/java-application-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -8,13 +8,13 @@
   <version>${version}</version>
 
   <properties>
-    <dependencies.slf4j.version>@slf4j.version@</dependencies.slf4j.version>
     <docker.repository>${dockerRepository}</docker.repository>
+    <maven-compiler.version>@maven-compiler-plugin.version@</maven-compiler.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <plugins.maven-compiler.version>@maven-compiler-plugin.version@</plugins.maven-compiler.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <slf4j.version>@slf4j.version@</slf4j.version>
   </properties>
 
   <dependencyManagement>
@@ -27,22 +27,22 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
-        <version>${dollar}{dependencies.slf4j.version}</version>
+        <version>${dollar}{slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jul-to-slf4j</artifactId>
-        <version>${dollar}{dependencies.slf4j.version}</version>
+        <version>${dollar}{slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>log4j-over-slf4j</artifactId>
-        <version>${dollar}{dependencies.slf4j.version}</version>
+        <version>${dollar}{slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>${dollar}{dependencies.slf4j.version}</version>
+        <version>${dollar}{slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -125,12 +125,12 @@
             <dependency>
               <groupId>org.slf4j</groupId>
               <artifactId>jcl-over-slf4j</artifactId>
-              <version>${dollar}{dependencies.slf4j.version}</version>
+              <version>${dollar}{slf4j.version}</version>
             </dependency>
             <dependency>
               <groupId>org.slf4j</groupId>
               <artifactId>slf4j-jdk14</artifactId>
-              <version>${dollar}{dependencies.slf4j.version}</version>
+              <version>${dollar}{slf4j.version}</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -142,7 +142,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${dollar}{plugins.maven-compiler.version}</version>
+          <version>${dollar}{maven-compiler.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -580,7 +580,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-compiler-plugin</artifactId>
-              <version>${dollar}{plugins.maven-compiler.version}</version>
+              <version>${dollar}{maven-compiler.version}</version>
               <configuration>
                 <compilerId>javac-with-errorprone</compilerId>
                 <forceJavacCompilerUse>true</forceJavacCompilerUse>

--- a/java-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/java-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -8,12 +8,12 @@
   <version>${version}</version>
 
   <properties>
-    <dependencies.slf4j.version>@slf4j.version@</dependencies.slf4j.version>
+    <maven-compiler.version>@maven-compiler-plugin.version@</maven-compiler.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <plugins.maven-compiler.version>@maven-compiler-plugin.version@</plugins.maven-compiler.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <slf4j.version>@slf4j.version@</slf4j.version>
   </properties>
 
   <dependencyManagement>
@@ -26,22 +26,22 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
-        <version>${dollar}{dependencies.slf4j.version}</version>
+        <version>${dollar}{slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jul-to-slf4j</artifactId>
-        <version>${dollar}{dependencies.slf4j.version}</version>
+        <version>${dollar}{slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>log4j-over-slf4j</artifactId>
-        <version>${dollar}{dependencies.slf4j.version}</version>
+        <version>${dollar}{slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>${dollar}{dependencies.slf4j.version}</version>
+        <version>${dollar}{slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.projectlombok</groupId>
@@ -70,7 +70,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
-        <version>${dollar}{dependencies.slf4j.version}</version>
+        <version>${dollar}{slf4j.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>
@@ -119,12 +119,12 @@
             <dependency>
               <groupId>org.slf4j</groupId>
               <artifactId>jcl-over-slf4j</artifactId>
-              <version>${dollar}{dependencies.slf4j.version}</version>
+              <version>${dollar}{slf4j.version}</version>
             </dependency>
             <dependency>
               <groupId>org.slf4j</groupId>
               <artifactId>slf4j-jdk14</artifactId>
-              <version>${dollar}{dependencies.slf4j.version}</version>
+              <version>${dollar}{slf4j.version}</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -136,7 +136,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${dollar}{plugins.maven-compiler.version}</version>
+          <version>${dollar}{maven-compiler.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -558,7 +558,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-compiler-plugin</artifactId>
-              <version>${dollar}{plugins.maven-compiler.version}</version>
+              <version>${dollar}{maven-compiler.version}</version>
               <configuration>
                 <compilerId>javac-with-errorprone</compilerId>
                 <forceJavacCompilerUse>true</forceJavacCompilerUse>


### PR DESCRIPTION
While it may help with ordering properties it's not a popular naming convention.