### PR TITLE
Dropped dependencyConvergence enforcer rule

### DIFF
--- a/java-application-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/java-application-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -336,8 +336,6 @@
                 <requireJavaVersion>
                   <version>[1.8,1.9)</version>
                 </requireJavaVersion>
-                <!-- When there are multiple versions of a dependency you have to choose which one to use. -->
-                <dependencyConvergence />
                 <requireReleaseDeps>
                   <message>No Snapshots Allowed!</message>
                 </requireReleaseDeps>

--- a/java-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/java-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -319,8 +319,6 @@
                 <requireJavaVersion>
                   <version>[1.8,1.9)</version>
                 </requireJavaVersion>
-                <!-- When there are multiple versions of a dependency you have to choose which one to use. -->
-                <dependencyConvergence />
                 <requireReleaseDeps>
                   <message>No Snapshots Allowed!</message>
                 </requireReleaseDeps>

--- a/kotlin-application-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-application-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -327,8 +327,6 @@
                 <requireJavaVersion>
                   <version>[1.8,1.9)</version>
                 </requireJavaVersion>
-                <!-- When there are multiple versions of a dependency you have to choose which one to use. -->
-                <dependencyConvergence />
                 <requireReleaseDeps>
                   <message>No Snapshots Allowed!</message>
                 </requireReleaseDeps>

--- a/kotlin-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -321,8 +321,6 @@
                 <requireJavaVersion>
                   <version>[1.8,1.9)</version>
                 </requireJavaVersion>
-                <!-- When there are multiple versions of a dependency you have to choose which one to use. -->
-                <dependencyConvergence />
                 <requireReleaseDeps>
                   <message>No Snapshots Allowed!</message>
                 </requireReleaseDeps>


### PR DESCRIPTION
The `requireUpperBoundDeps` rule is sufficient.