### PR TITLE
Removed unused property from Kotlin library test

### DIFF
--- a/kotlin-library-maven-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/kotlin-library-maven-archetype/src/test/resources/projects/basic/archetype.properties
@@ -7,6 +7,5 @@ projectName=ArchetypeTest
 organizationName=GantSign Ltd.
 licenseName=mit
 copyrightStartYear=2017
-dockerImageName=archetype/test
 intellijCodeStyleUrl=https://raw.githubusercontent.com/gantsign/code-style-intellij/2.0.0/GantSign2.xml
 intellijInspectionProfileUrl=https://raw.githubusercontent.com/gantsign/inspection-profile-intellij/1.0.0/GantSign.xml


### PR DESCRIPTION
It's used by the application but not the library.