### PR TITLE
Display GPG expiry date during build

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -13,6 +13,8 @@ gpg --fast-import .travis/codesigning.asc
 
 set -x
 
+gpg --list-secret-keys
+
 ./mvnw deploy \
     -P publish-artifacts \
     --settings .travis/settings.xml \


### PR DESCRIPTION
To help diagnose signing issues.