### PR TITLE
Display GPG sub-key expiry date during build

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -13,7 +13,7 @@ gpg --fast-import .travis/codesigning.asc
 
 set -x
 
-gpg --list-secret-keys
+gpg --list-secret-keys --verbose
 
 ./mvnw deploy \
     -P publish-artifacts \


### PR DESCRIPTION
To help diagnose signing issues.