### PR TITLE
Changed to test with OpenJDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+jdk:
+  - openjdk8
+
 install: .travis/install.sh
 
 jobs:


### PR DESCRIPTION
Free support for Oracle JDK 8 has ended.