### PR TITLE
Ensured codesigning.asc won't be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -342,3 +342,6 @@ $RECYCLE.BIN/
 
 # Ignore flattened POMs
 .flattened-pom.xml
+
+# Ignore plain GPG key
+codesigning.asc


### PR DESCRIPTION
Added to `.gitignore`.