### PR TITLE
Suppressed inheritance of Maven Site config from common-parent

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project name="Java Application Maven Archetype" xmlns="http://maven.apache.org/DECORATION/1.0.0"
+<project name="Java Application Maven Archetype"
+         combine.self="override"
+         xmlns="http://maven.apache.org/DECORATION/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
 


### PR DESCRIPTION
Fixes error:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.8.2:site (default-site) on project maven-archetypes: SiteToolException: The site descriptor cannot be resolved from the repository: ArtifactResolutionException: Unable to locate site descriptor: Could not transfer artifact com.github.gantsign.parent:common-parent:xml:site_en:0.9.4 from/to sonatype-apache (https://repository.apache.org/content/repositories/releases/)
```