### PR TITLE
Specify empty relativePath for external POMs

### DIFF
--- a/java-application-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/java-application-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -7,6 +7,7 @@
     <groupId>com.github.gantsign.parent</groupId>
     <artifactId>java-parent</artifactId>
     <version>${gantsign-parent.version}</version>
+    <relativePath />
   </parent>
 
   <groupId>${dollar}{groupId}</groupId>

--- a/java-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/java-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -7,6 +7,7 @@
     <groupId>com.github.gantsign.parent</groupId>
     <artifactId>java-parent</artifactId>
     <version>${gantsign-parent.version}</version>
+    <relativePath />
   </parent>
 
   <groupId>${dollar}{groupId}</groupId>

--- a/kotlin-application-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-application-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -7,6 +7,7 @@
     <groupId>com.github.gantsign.parent</groupId>
     <artifactId>kotlin-parent</artifactId>
     <version>${gantsign-parent.version}</version>
+    <relativePath />
   </parent>
 
   <groupId>${dollar}{groupId}</groupId>

--- a/kotlin-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -7,6 +7,7 @@
     <groupId>com.github.gantsign.parent</groupId>
     <artifactId>kotlin-parent</artifactId>
     <version>${gantsign-parent.version}</version>
+    <relativePath />
   </parent>
 
   <groupId>${dollar}{groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
     <groupId>com.github.gantsign.parent</groupId>
     <artifactId>common-parent</artifactId>
     <version>0.9.5</version>
+    <relativePath />
   </parent>
 
   <groupId>com.github.gantsign.maven.archetypes</groupId>


### PR DESCRIPTION
Tells Maven the POM needs to be downloaded.