### PR TITLE
Removed sudo key from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ install: .travis/install.sh
 jobs:
   include:
     - stage: Test
-      sudo: required
 
       # Require Docker
       services:


### PR DESCRIPTION
The key `sudo` has no effect anymore.