### PR TITLE
Simplified release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,19 +27,10 @@ jobs:
           export GIT_TAG="${GITHUB_REF#refs/tags/}"
           .github/scripts/build.sh
 
-  build-all:
-    if: ${{ always() }}
-    name: Build (matrix)
-    runs-on: ubuntu-18.04
-    needs: build
-    steps:
-      - name: Check build matrix status
-        run: "[[ '${{ needs.build.result }}' == 'success' ]] || exit 1"
-
   deploy:
     name: Maven deploy
     runs-on: ubuntu-18.04
-    needs: build-all
+    needs: build
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
`build-all` job is unnecessary.