### PR TITLE
Changed library archetypes to use Java 11

### DIFF
--- a/java-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/java-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <!-- See https://github.com/gantsign/maven-parent-poms -->
     <groupId>com.github.gantsign.parent</groupId>
-    <artifactId>java8-parent</artifactId>
+    <artifactId>java-parent</artifactId>
     <!-- For Java 11 use the following alternate parent artifact ID -->
     <!-- <artifactId>java-parent</artifactId> -->
     <version>${gantsign-parent.version}</version>
@@ -24,8 +24,8 @@
     <jacoco.file.minimum-coverage-ratio>0.75</jacoco.file.minimum-coverage-ratio>
     <jacoco.skip>false</jacoco.skip>
 
-    <java.require.version>[1.8,9)</java.require.version>
-    <java.target.version>1.8</java.target.version>
+    <java.require.version>[11,12)</java.require.version>
+    <java.target.version>11</java.target.version>
 
     <!-- Check dependencies are used, declared and have the correct scope -->
     <mdep.analyze.skip>false</mdep.analyze.skip>

--- a/kotlin-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-library-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -22,8 +22,8 @@
     <jacoco.file.minimum-coverage-ratio>0.75</jacoco.file.minimum-coverage-ratio>
     <jacoco.skip>false</jacoco.skip>
 
-    <java.target.version>1.8</java.target.version>
-    <java.require.version>[1.8,9)</java.require.version>
+    <java.target.version>11</java.target.version>
+    <java.require.version>[11,12)</java.require.version>
 
     <!-- Check dependencies are used, declared and have the correct scope -->
     <mdep.analyze.skip>false</mdep.analyze.skip>


### PR DESCRIPTION
Java 11 is becoming the new baseline for libraries instead of Java 8.