### PR TITLE
Changed Kotlin application archetype to use Java 11

### DIFF
--- a/kotlin-application-maven-archetype/src/main/resources/archetype-resources/DEVELOPMENT.md
+++ b/kotlin-application-maven-archetype/src/main/resources/archetype-resources/DEVELOPMENT.md
@@ -6,19 +6,19 @@ $h1 ${projectName}
 
 $h2 Requirements
 
-* Java 8
+* Java 11
 * Direct internet access / Apache Maven proxy configured
 
 $h3 Changing the required Java version
 
-Java 8 is required by default. To move the project to Java 11, change the following two properties
+Java 11 is required by default. To move the project to Java 17, change the following two properties
 in your `pom.xml`:
 
 ```xml
 <properties>
   ...
-  <java.require.version>[11,12)</java.require.version>
-  <java.target.version>11</java.target.version>
+  <java.require.version>[17,18)</java.require.version>
+  <java.target.version>17</java.target.version>
   ...
 </properties>
 ```

--- a/kotlin-application-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kotlin-application-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -24,8 +24,8 @@
     <jacoco.file.minimum-coverage-ratio>0.75</jacoco.file.minimum-coverage-ratio>
     <jacoco.skip>false</jacoco.skip>
 
-    <java.target.version>1.8</java.target.version>
-    <java.require.version>[1.8,9)</java.require.version>
+    <java.target.version>11</java.target.version>
+    <java.require.version>[11,12)</java.require.version>
 
     <!-- Check dependencies are used, declared and have the correct scope -->
     <mdep.analyze.skip>false</mdep.analyze.skip>


### PR DESCRIPTION
It's getting difficult to use Java 8 due to some Java libraries and Maven plugins using Java 11.