### PR TITLE
Dropped support for Java 8

### DIFF
--- a/java-application-maven-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/java-application-maven-archetype/src/main/resources/archetype-resources/pom.xml
@@ -6,8 +6,6 @@
     <!-- See https://github.com/gantsign/maven-parent-poms -->
     <groupId>com.github.gantsign.parent</groupId>
     <artifactId>java-parent</artifactId>
-    <!-- For Java 8 use the following alternate parent artifact ID -->
-    <!-- <artifactId>java8-parent</artifactId> -->
     <version>${gantsign-parent.version}</version>
     <relativePath />
   </parent>


### PR DESCRIPTION
It's getting difficult to use due to some Java libraries and Maven plugins using Java 11.